### PR TITLE
Update to upstream v3.0.0; build + release to ghcr via Actions

### DIFF
--- a/.github/scripts/php-floor.py
+++ b/.github/scripts/php-floor.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""Print the minimum PHP major.minor required by an upstream composer.json.
+
+Reads composer.json on stdin and prints the floor of its `require.php`
+constraint (e.g. ">=8.1", "^8.1", ">=8.1 <9.0", "8.1.*" all -> "8.1").
+
+The floor is the smallest major.minor mentioned in the constraint: for a
+range like ">=8.1 <9.0" the lower bound 8.1 is the requirement; the 9.0 upper
+bound is not. Exits non-zero if no version can be parsed, so callers fail loud
+rather than silently shipping against an unknown requirement.
+
+Used by both check-releases.yml (to decide whether to raise the tracked PHP)
+and build.yml (to assert the built image satisfies upstream before publishing).
+"""
+import json
+import re
+import sys
+
+try:
+    data = json.load(sys.stdin)
+except json.JSONDecodeError as exc:
+    sys.exit(f"php-floor: could not parse composer.json: {exc}")
+
+constraint = data.get("require", {}).get("php", "")
+versions = re.findall(r"(\d+)\.(\d+)", constraint)
+if not versions:
+    sys.exit(f"php-floor: no PHP version found in require.php: {constraint!r}")
+
+major, minor = min((int(a), int(b)) for a, b in versions)
+print(f"{major}.{minor}")

--- a/.github/tracked-versions.json
+++ b/.github/tracked-versions.json
@@ -1,0 +1,9 @@
+{
+  "unifi_api_browser": {
+    "repo": "Art-of-WiFi/UniFi-API-browser",
+    "version": "v3.0.0"
+  },
+  "base": {
+    "php": "8.3"
+  }
+}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,229 @@
+name: Build and release image
+
+# Builds the multi-arch container image, smoke-tests it, and on success pushes
+# immutable tags to ghcr.io and cuts an immutable GitHub Release.
+#
+# Adapted from the truenas-community-sysexts release pattern. Differences:
+#   * A container is fully testable in CI, so there is no prerelease /
+#     hardware-test / promote gate -- the smoke test below IS the gate. If it
+#     passes the image goes straight to Latest.
+#   * The artifact is the image in ghcr (pinned by digest), not a .raw attached
+#     to the Release. The Release records the digest + pull commands.
+#   * Every run cuts a UNIQUE release tag (v<ver>-r<run_number>) so it never
+#     collides with GitHub's immutable-release tag burn, exactly like the sysext
+#     repo's -r<run> scheme.
+#
+# Triggered manually (workflow_dispatch) or by check-releases.yml (workflow_call)
+# when a new upstream version is detected.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Upstream UniFi-API-browser tag to build (blank = latest tracked in .github/tracked-versions.json)'
+        required: false
+        default: ''
+      php_version:
+        description: 'PHP major.minor for the base image (blank = tracked base.php)'
+        required: false
+        default: ''
+  workflow_call:
+    inputs:
+      version:
+        type: string
+        required: false
+        default: ''
+      php_version:
+        type: string
+        required: false
+        default: ''
+
+permissions:
+  contents: write   # create the GitHub Release / tag
+  packages: write   # push the image to ghcr.io
+
+concurrency:
+  group: build-release
+  cancel-in-progress: false
+
+env:
+  REGISTRY: ghcr.io
+  PLATFORMS: linux/amd64,linux/arm64,linux/arm/v7
+
+defaults:
+  run:
+    shell: bash -euo pipefail {0}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Resolve version and image name
+        id: vars
+        run: |
+          VERSION="${{ inputs.version }}"
+          if [ -z "$VERSION" ]; then
+            VERSION=$(python3 -c "import json; print(json.load(open('.github/tracked-versions.json'))['unifi_api_browser']['version'])")
+          fi
+          PHP_VERSION="${{ inputs.php_version }}"
+          if [ -z "$PHP_VERSION" ]; then
+            PHP_VERSION=$(python3 -c "import json; print(json.load(open('.github/tracked-versions.json'))['base']['php'])")
+          fi
+          VERSION_CLEAN="${VERSION#v}"
+          # ghcr requires a lowercase path; github.repository has mixed case.
+          IMAGE="${REGISTRY}/${GITHUB_REPOSITORY,,}"
+          {
+            echo "version=${VERSION}"
+            echo "version_clean=${VERSION_CLEAN}"
+            echo "php_version=${PHP_VERSION}"
+            echo "image=${IMAGE}"
+            echo "short_sha=${GITHUB_SHA::7}"
+          } >> "$GITHUB_OUTPUT"
+          echo "Building upstream ${VERSION} on PHP ${PHP_VERSION} -> ${IMAGE}:${VERSION_CLEAN}-r${GITHUB_RUN_NUMBER}"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # --- Gate: build amd64 only, load it locally, boot it and probe it. ---
+      # If this fails we never log in, never push, never cut a release.
+      - name: Build amd64 image for smoke test
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64
+          load: true
+          tags: unifibrowser:smoketest
+          build-args: |
+            PHP_VERSION=${{ steps.vars.outputs.php_version }}
+            UNIFI_BROWSER_VERSION=${{ steps.vars.outputs.version }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Smoke test the image
+        run: |
+          cid=$(docker run -d -p 8000:8000 unifibrowser:smoketest)
+          trap 'docker rm -f "$cid" >/dev/null 2>&1 || true' EXIT
+
+          code=000
+          for _ in $(seq 1 20); do
+            code=$(curl -s -o /dev/null -w '%{http_code}' http://localhost:8000/UniFi-API-browser/ || true)
+            [ "$code" = "200" ] && break
+            sleep 1
+          done
+          echo "HTTP status: ${code}"
+          if [ "$code" != "200" ]; then
+            echo "::error title=smoke-test::app did not return HTTP 200"
+            docker logs "$cid" || true
+            exit 1
+          fi
+
+          # The v3.0.0 login page renders this title; catches a fatal PHP/Twig error
+          # that still returns 200 with an error body.
+          if ! curl -s http://localhost:8000/UniFi-API-browser/ | grep -qi 'UniFi API Browser'; then
+            echo "::error title=smoke-test::login page title missing -- likely a PHP/Twig fatal"
+            docker logs "$cid" || true
+            exit 1
+          fi
+
+          # Assert the image's PHP satisfies upstream's DECLARED floor (its
+          # composer.json require.php), not a hardcoded number. If upstream
+          # raised the floor above the pinned base.php, this fails loudly with
+          # the exact version needed instead of shipping a broken image --
+          # check-releases.yml should have already auto-bumped base.php, so this
+          # is the safety net for a manual build that skipped that.
+          FLOOR=$(curl -fsSL "https://raw.githubusercontent.com/Art-of-WiFi/UniFi-API-browser/${{ steps.vars.outputs.version }}/composer.json" | python3 .github/scripts/php-floor.py)
+          FLOOR_ID=$(awk -F. '{ printf "%d%02d00", $1, $2 }' <<<"$FLOOR")
+          echo "upstream PHP floor: ${FLOOR} (id ${FLOOR_ID})"
+          if ! docker exec -e FLOOR_ID="$FLOOR_ID" "$cid" php -r 'exit(PHP_VERSION_ID >= (int)getenv("FLOOR_ID") ? 0 : 1);'; then
+            echo "::error title=smoke-test::image PHP $(docker exec "$cid" php -r 'echo PHP_VERSION;') is below upstream's required ${FLOOR}. Bump base.php in .github/tracked-versions.json."
+            exit 1
+          fi
+
+          echo "smoke-test OK (PHP satisfies upstream floor ${FLOOR})"
+
+      # --- Publish: all platforms, immutable tags, immutable release. ---
+      - name: Log in to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push multi-arch image
+        id: push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: ${{ env.PLATFORMS }}
+          push: true
+          # Keep the manifest list clean (no unknown/unknown provenance entries).
+          provenance: false
+          build-args: |
+            PHP_VERSION=${{ steps.vars.outputs.php_version }}
+            UNIFI_BROWSER_VERSION=${{ steps.vars.outputs.version }}
+          tags: |
+            ${{ steps.vars.outputs.image }}:${{ steps.vars.outputs.version_clean }}-r${{ github.run_number }}
+            ${{ steps.vars.outputs.image }}:${{ steps.vars.outputs.version_clean }}
+            ${{ steps.vars.outputs.image }}:latest
+            ${{ steps.vars.outputs.image }}:sha-${{ steps.vars.outputs.short_sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Render release notes
+        env:
+          IMAGE: ${{ steps.vars.outputs.image }}
+          VERSION: ${{ steps.vars.outputs.version }}
+          VERSION_CLEAN: ${{ steps.vars.outputs.version_clean }}
+          PHP_VERSION: ${{ steps.vars.outputs.php_version }}
+          RUN_NUMBER: ${{ github.run_number }}
+          DIGEST: ${{ steps.push.outputs.digest }}
+          BUILD_SHA: ${{ github.sha }}
+          REPO: ${{ github.repository }}
+        run: |
+          IMMUTABLE_TAG="${VERSION_CLEAN}-r${RUN_NUMBER}"
+          cat > release-notes.md <<EOF
+          ## UniFi API Browser container — upstream \`${VERSION}\`
+
+          | Field | Value |
+          | --- | --- |
+          | Upstream | [Art-of-WiFi/UniFi-API-browser@${VERSION}](https://github.com/Art-of-WiFi/UniFi-API-browser/releases/tag/${VERSION}) |
+          | PHP base | \`php:${PHP_VERSION}-cli-alpine\` |
+          | Immutable image | \`${IMAGE}:${IMMUTABLE_TAG}\` |
+          | Digest | \`${DIGEST}\` |
+          | Platforms | \`linux/amd64\`, \`linux/arm64\`, \`linux/arm/v7\` |
+          | Source commit | [\`${BUILD_SHA}\`](https://github.com/${REPO}/commit/${BUILD_SHA}) |
+
+          Built and smoke-tested in CI (boots, serves HTTP 200, PHP ≥ 8.1).
+
+          ### Pull (immutable, by digest)
+          \`\`\`bash
+          docker pull ${IMAGE}@${DIGEST}
+          \`\`\`
+
+          ### Pull (this exact build)
+          \`\`\`bash
+          docker pull ${IMAGE}:${IMMUTABLE_TAG}
+          \`\`\`
+
+          The floating tags \`:latest\` and \`:${VERSION_CLEAN}\` also point at this build.
+          EOF
+          echo "=== release notes ==="
+          cat release-notes.md
+
+      - name: Create immutable GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="v${{ steps.vars.outputs.version_clean }}-r${{ github.run_number }}"
+          gh release create "$TAG" \
+            --title "UniFi API Browser v${{ steps.vars.outputs.version_clean }} (r${{ github.run_number }})" \
+            --notes-file release-notes.md \
+            --latest
+          echo "Created release ${TAG}"

--- a/.github/workflows/check-releases.yml
+++ b/.github/workflows/check-releases.yml
@@ -1,0 +1,125 @@
+name: Check for new upstream release
+
+# Daily check of Art-of-WiFi/UniFi-API-browser against .github/tracked-versions.json.
+# Two independent things can move the pin:
+#   1. A newer upstream release -> bump unifi_api_browser.version.
+#   2. Upstream raising its composer.json `require.php` floor ABOVE the pinned
+#      base.php -> raise base.php to that floor (the official php:<ver>-alpine
+#      image guarantees the tag exists). base.php only ever moves UP, so a lower
+#      upstream floor never downgrades it.
+# If either moved, commit the new pin and call build.yml to build + release.
+#
+# It deliberately does NOT watch Alpine or PHP release feeds, so a plain base
+# patch (alpine 3.20->3.21, php 8.3.15->8.3.20) never triggers a rebuild.
+#
+# build.yml is called as a reusable workflow in the same run with the resolved
+# version + php as inputs, so no PAT/App token is needed (unlike the sysext repo).
+
+on:
+  schedule:
+    - cron: '0 6 * * *'  # daily at 06:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: check-releases
+  cancel-in-progress: false
+
+defaults:
+  run:
+    shell: bash -euo pipefail {0}
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    outputs:
+      changed: ${{ steps.check.outputs.changed }}
+      version: ${{ steps.check.outputs.version }}
+      php_version: ${{ steps.check.outputs.php_version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Resolve upstream version and PHP floor
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          REPO=$(python3 -c "import json; print(json.load(open('.github/tracked-versions.json'))['unifi_api_browser']['repo'])")
+          CUR_VERSION=$(python3 -c "import json; print(json.load(open('.github/tracked-versions.json'))['unifi_api_browser']['version'])")
+          CUR_PHP=$(python3 -c "import json; print(json.load(open('.github/tracked-versions.json'))['base']['php'])")
+
+          # /releases/latest excludes drafts and prereleases.
+          LATEST=$(gh api "repos/${REPO}/releases/latest" -q .tag_name)
+          echo "tracked: version=${CUR_VERSION} php=${CUR_PHP}; upstream latest=${LATEST}"
+
+          # Version we'd build: upstream latest if it is strictly newer, else stay.
+          NEW_VERSION="$CUR_VERSION"
+          if [ -n "$LATEST" ] && [ "$LATEST" != "$CUR_VERSION" ]; then
+            HIGHER=$(printf '%s\n%s\n' "${CUR_VERSION#v}" "${LATEST#v}" | sort -V | tail -1)
+            if [ "$HIGHER" = "${LATEST#v}" ]; then
+              NEW_VERSION="$LATEST"
+            else
+              echo "Upstream ${LATEST} is not newer than tracked ${CUR_VERSION}; ignoring."
+            fi
+          fi
+
+          # PHP floor declared by the version we'd build. base.php only moves up.
+          FLOOR=$(curl -fsSL "https://raw.githubusercontent.com/${REPO}/${NEW_VERSION}/composer.json" | python3 .github/scripts/php-floor.py)
+          NEW_PHP=$(printf '%s\n%s\n' "$CUR_PHP" "$FLOOR" | sort -V | tail -1)
+          echo "upstream PHP floor=${FLOOR}; resolved base.php=${NEW_PHP}"
+
+          if [ "$NEW_VERSION" = "$CUR_VERSION" ] && [ "$NEW_PHP" = "$CUR_PHP" ]; then
+            echo "Nothing to do."
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          python3 - "$NEW_VERSION" "$NEW_PHP" <<'PY'
+          import json, sys
+          path = '.github/tracked-versions.json'
+          d = json.load(open(path))
+          d['unifi_api_browser']['version'] = sys.argv[1]
+          d['base']['php'] = sys.argv[2]
+          with open(path, 'w') as f:
+              json.dump(d, f, indent=2)
+              f.write('\n')
+          PY
+
+          if [ "$NEW_VERSION" != "$CUR_VERSION" ] && [ "$NEW_PHP" != "$CUR_PHP" ]; then
+            MSG="Update tracked UniFi-API-browser to ${NEW_VERSION} and PHP base to ${NEW_PHP}"
+          elif [ "$NEW_VERSION" != "$CUR_VERSION" ]; then
+            MSG="Update tracked UniFi-API-browser to ${NEW_VERSION}"
+          else
+            MSG="Update tracked PHP base to ${NEW_PHP} (upstream raised its floor)"
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add .github/tracked-versions.json
+          git commit -m "$MSG"
+          if ! git push; then
+            git pull --rebase
+            git push
+          fi
+
+          {
+            echo "changed=true"
+            echo "version=${NEW_VERSION}"
+            echo "php_version=${NEW_PHP}"
+          } >> "$GITHUB_OUTPUT"
+          echo "::notice title=tracked bump::${MSG}"
+
+  build:
+    needs: check
+    if: needs.check.outputs.changed == 'true'
+    permissions:
+      contents: write
+      packages: write
+    uses: ./.github/workflows/build.yml
+    with:
+      version: ${{ needs.check.outputs.version }}
+      php_version: ${{ needs.check.outputs.php_version }}
+    secrets: inherit

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,35 @@
-# Use alpine base image
-FROM alpine:3.20
+# PHP major.minor is the contract with upstream. check-releases.yml raises it
+# only to satisfy UniFi-API-browser's composer.json `require.php` floor -- a
+# plain Alpine or PHP patch release never bumps it, so it never triggers a
+# rebuild. Using the official php image (not Alpine's phpNN packages) means any
+# version the floor demands is guaranteed to exist as a tag.
+ARG PHP_VERSION=8.3
 
-# Copy the current directory contents into the container at /
-COPY /files .
+# The official PHP CLI image already bundles every extension this app needs
+# (curl, ctype, mbstring, openssl, session, tokenizer, json), so there is no
+# docker-php-ext-install step. -alpine keeps the image small.
+FROM php:${PHP_VERSION}-cli-alpine
 
-# Install any needed packages
+# Upstream UniFi-API-browser version to install.
+# Bump via .github/tracked-versions.json (check-releases.yml does this
+# automatically). See https://github.com/Art-of-WiFi/UniFi-API-browser/releases
+ARG UNIFI_BROWSER_VERSION=v3.0.0
 
-RUN apk update \
-  && apk add --no-cache php php-session php-curl php-tokenizer composer git \
-  && git clone --depth 1 https://github.com/Art-of-Wifi/UniFi-API-browser.git \
+WORKDIR /app
+
+# start.sh, config.php and users.php
+COPY files/ ./
+
+# Upstream ships a committed vendor/ dir, so no composer install is needed.
+# git is only used for the shallow clone and removed in the same layer.
+RUN apk add --no-cache git \
+  && git clone --depth 1 --branch "${UNIFI_BROWSER_VERSION}" https://github.com/Art-of-Wifi/UniFi-API-browser.git \
   && apk del git \
   && chmod +x start.sh \
-  && cd UniFi-API-browser \
-  && cd .. \
-  && mv config.php /UniFi-API-browser/config \
-  && mv users.php /UniFi-API-browser/config
+  && mv config.php UniFi-API-browser/config \
+  && mv users.php UniFi-API-browser/config
 
-# Define environment variable
-ENV PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+# Define environment variables
 ENV LANG="C.UTF-8"
 ENV TZ="America/Los_Angeles"
 ENV USER="your unifi username"
@@ -31,9 +43,6 @@ ENV APIBROWSERUSER="admin"
 # this sets password for APIBROWSERUSER to admin - please change when you do this
 ENV APIBROWSERPASS="c7ad44cbad762a5da0a452f9e854fdc1e0e7a52a38015f23f3eab1d80b931dd472634dfac71cd34ebc35d16ab7fb8a90c81f975113d6c7538dc69dd8de9077ec"
 
-
-# Run  when the container launches
-# ENTRYPOINT ["./start.sh"]
-# ENTRYPOINT ["./bin/ash"]
+# Run when the container launches
 CMD ["sh", "./start.sh"]
 EXPOSE 8000/tcp

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Includes support for UniFiOS on UDMP - see note on ports
 ## Getting Running
 To get started this is the minimum number of options, be sure to append each envar with the required text (esp the SHA512):
 
-`docker run --name unifiapibrowser -p:8000:8000 -e USER= -e PASSWORD= -e UNIFIURL= -e APIBROWSERPASS=    scyto/unifibrowser`
+`docker run --name unifiapibrowser -p:8000:8000 -e USER= -e PASSWORD= -e UNIFIURL= -e APIBROWSERPASS=    ghcr.io/scyto/docker-unifibrowser`
 
 This will run the container on host port 8000/tcp.
 
@@ -43,7 +43,7 @@ services:
       UNIFIURL: https://192.168.1.1
       PORT: 443
       DISPLAYNAME: Home
-    image: scyto/unifibrowser
+    image: ghcr.io/scyto/docker-unifibrowser
  ```   
 
 ## Using Multiple Unifi Controllers

--- a/multi-arch-linx-build.ps1
+++ b/multi-arch-linx-build.ps1
@@ -1,1 +1,0 @@
-docker buildx build -t scyto/unifibrowser:latest --no-cache --push --platform linux/amd64,linux/arm64,linux/ppc64le,linux/s390x,linux/386,linux/arm/v7,linux/arm/v6 .


### PR DESCRIPTION
Closes #17.

Two years of drift, modernised. Verified locally end-to-end (built the image, booted it, smoke-tested HTTP 200 on PHP 8.3 **and** 8.4, and loaded the classic `config.php`/`users.php` under PHP 8.3 with warnings on — clean).

## What changed

### Image
- **Pin upstream.** `UNIFI_BROWSER_VERSION` build ARG (default `v3.0.0`) replaces the unpinned `git clone` of `master` → reproducible builds.
- **Official PHP base.** `FROM php:${PHP_VERSION}-cli-alpine` instead of Alpine's `phpNN` packages. It bundles every extension the app needs (`curl ctype mbstring openssl session tokenizer json`), so the extension-install step is gone. v3.0.0 requires PHP ≥ 8.1; this ships 8.3.

### CI / release — mirrors the `truenas-community-sysexts` release pattern
- **`.github/tracked-versions.json`** — single source of truth for the pinned upstream version + PHP base.
- **`build.yml`** — smoke-tests an amd64 build (boots, HTTP 200, PHP satisfies upstream's *declared* `composer.json` floor), then pushes a multi-arch image (`amd64/arm64/armv7`) to **ghcr.io** with **immutable per-run tags** (`<ver>-r<run>`) and cuts an **immutable GitHub Release** recording the digest. The smoke test is the gate → a passing build goes straight to Latest.
- **`check-releases.yml`** — daily upstream watch. Bumps the version on a new release, and raises `base.php` **only** when upstream raises its `require.php` floor above the pin (never on a plain Alpine/PHP patch, never downward) → then calls `build.yml` as a reusable workflow (no PAT/App token needed).
- **`php-floor.py`** — shared parser for upstream's `require.php` floor.

### Housekeeping
- README image refs → `ghcr.io/scyto/docker-unifibrowser`.
- Removed `multi-arch-linx-build.ps1` (replaced by `build.yml`).

## How to try it after merge
The workflows are **dispatch-driven** (faithful to the sysext pattern), so they do **not** run on this PR or on push. To publish the first image: **Actions → Build and release image → Run workflow**. The daily checker handles upstream bumps after that.

## Follow-up (not in this PR)
Expose v3.0.0's official UniFi Network Application API-key auth via env-driven `config.php` — tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)