### PR TITLE
Decompose release into discrete build / smoke / publish phase workflows

### DIFF
--- a/.github/scripts/smoke-test.sh
+++ b/.github/scripts/smoke-test.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Smoke-test a UniFi-API-browser image: boot it, confirm it serves the login
+# page (HTTP 200), and confirm its PHP satisfies upstream's real runtime floor
+# (vendor/composer/platform_check.php -- the locked requirement, not the lagging
+# composer.json require.php).
+#
+# Shared by ci.yml (tests a locally-built amd64 image) and smoke.yml (tests an
+# image pulled from ghcr by digest), so both gates run the identical checks.
+#
+# Usage: smoke-test.sh <image-ref> <upstream-version>
+#   <image-ref>        anything `docker run` accepts (a local tag or image@sha256:...)
+#   <upstream-version> the UniFi-API-browser tag, e.g. v3.0.0 (for the floor lookup)
+set -euo pipefail
+
+IMAGE="${1:?usage: smoke-test.sh <image-ref> <upstream-version>}"
+VERSION="${2:?usage: smoke-test.sh <image-ref> <upstream-version>}"
+HERE="$(cd "$(dirname "$0")" && pwd)"
+
+cid=$(docker run -d -p 8000:8000 "$IMAGE")
+trap 'docker rm -f "$cid" >/dev/null 2>&1 || true' EXIT
+
+code=000
+for _ in $(seq 1 20); do
+  code=$(curl -s -o /dev/null -w '%{http_code}' http://localhost:8000/UniFi-API-browser/ || true)
+  [ "$code" = "200" ] && break
+  sleep 1
+done
+echo "HTTP status: ${code}"
+if [ "$code" != "200" ]; then
+  echo "::error title=smoke-test::app did not return HTTP 200"
+  docker logs "$cid" || true
+  exit 1
+fi
+
+# Catches a fatal PHP/Twig error that still returns 200 with an error body.
+if ! curl -s http://localhost:8000/UniFi-API-browser/ | grep -qi 'UniFi API Browser'; then
+  echo "::error title=smoke-test::login page title missing -- likely a PHP/Twig fatal"
+  docker logs "$cid" || true
+  exit 1
+fi
+
+# Assert PHP satisfies upstream's AUTHORITATIVE runtime floor. composer.json's
+# require.php lags (v3.0.0 declares >=8.1 but the locked deps need >=8.2, and an
+# 8.1 image 500s on every request), so read the floor from platform_check.php.
+FLOOR=$(curl -fsSL "https://raw.githubusercontent.com/Art-of-WiFi/UniFi-API-browser/${VERSION}/vendor/composer/platform_check.php" | python3 "${HERE}/php-floor.py")
+FLOOR_ID=$(awk -F. '{ printf "%d%02d00", $1, $2 }' <<<"$FLOOR")
+echo "upstream PHP floor: ${FLOOR} (id ${FLOOR_ID})"
+if ! docker exec -e FLOOR_ID="$FLOOR_ID" "$cid" php -r 'exit(PHP_VERSION_ID >= (int)getenv("FLOOR_ID") ? 0 : 1);'; then
+  echo "::error title=smoke-test::image PHP $(docker exec "$cid" php -r 'echo PHP_VERSION;') is below upstream's required ${FLOOR}. Bump base.php in .github/tracked-versions.json."
+  exit 1
+fi
+
+echo "smoke-test OK (PHP satisfies upstream floor ${FLOOR})"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,37 +1,15 @@
-name: Build and smoke test
+name: Build image
 
-# Read-only CI gate. Builds the amd64 image and smoke-tests it (boots, serves
-# HTTP 200, PHP satisfies upstream's real runtime floor). It NEVER logs in,
-# pushes, or releases, and declares only `contents: read` -- so it is safe to
-# run against a PR-controlled Dockerfile (a malicious RUN gets only a read-only
-# token, and checkout drops it from the workspace anyway).
+# Phase 1 of the release path. Builds the multi-arch image and pushes it to ghcr
+# under an immutable per-run tag (<version>-r<run> + sha-<sha>) -- NOT the
+# floating :latest / :<version> tags, which release.yml applies only after the
+# smoke phase passes. Outputs the pushed digest so smoke.yml tests exactly this
+# artifact and release.yml promotes exactly this digest (no rebuild).
 #
-# Triggered by:
-#   * pull_request  -> red/green check on the PR
-#   * workflow_call -> release.yml runs this as a required gate before publishing
-#   * workflow_dispatch -> ad-hoc smoke test of the tracked (or overridden) pin
-#
-# Mirrors the sysext repo's build-sysext "CI smoke" workflow; publishing lives
-# in release.yml.
+# Run standalone (workflow_dispatch) to produce an image, or via workflow_call
+# from release.yml as the first phase of the golden path.
 
 on:
-  pull_request:
-    paths:
-      - 'Dockerfile'
-      - 'files/**'
-      - '.github/workflows/build.yml'
-      - '.github/tracked-versions.json'
-      - '.github/scripts/**'
-  workflow_dispatch:
-    inputs:
-      version:
-        description: 'Upstream UniFi-API-browser tag (blank = latest tracked)'
-        required: false
-        default: ''
-      php_version:
-        description: 'PHP major.minor (blank = tracked base.php)'
-        required: false
-        default: ''
   workflow_call:
     inputs:
       version:
@@ -42,13 +20,43 @@ on:
         type: string
         required: false
         default: ''
+    outputs:
+      image:
+        description: 'ghcr image path (no tag)'
+        value: ${{ jobs.build.outputs.image }}
+      digest:
+        description: 'Pushed manifest digest (sha256:...)'
+        value: ${{ jobs.build.outputs.digest }}
+      version:
+        description: 'Resolved upstream version'
+        value: ${{ jobs.build.outputs.version }}
+      version_clean:
+        description: 'Resolved upstream version without leading v'
+        value: ${{ jobs.build.outputs.version_clean }}
+      php_version:
+        description: 'Resolved PHP base version'
+        value: ${{ jobs.build.outputs.php_version }}
+      run_tag:
+        description: 'Immutable per-run tag pushed (<version>-r<run>)'
+        value: ${{ jobs.build.outputs.run_tag }}
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Upstream UniFi-API-browser tag (blank = latest tracked)'
+        required: false
+        default: ''
+      php_version:
+        description: 'PHP major.minor (blank = tracked base.php)'
+        required: false
+        default: ''
 
 permissions:
   contents: read
+  packages: write
 
-concurrency:
-  group: build-${{ github.event_name }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+env:
+  REGISTRY: ghcr.io
+  PLATFORMS: linux/amd64,linux/arm64,linux/arm/v7
 
 defaults:
   run:
@@ -57,14 +65,19 @@ defaults:
 jobs:
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
+    outputs:
+      image: ${{ steps.vars.outputs.image }}
+      digest: ${{ steps.push.outputs.digest }}
+      version: ${{ steps.vars.outputs.version }}
+      version_clean: ${{ steps.vars.outputs.version_clean }}
+      php_version: ${{ steps.vars.outputs.php_version }}
+      run_tag: ${{ steps.vars.outputs.run_tag }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-        with:
-          persist-credentials: false
 
-      - name: Resolve version and PHP base
+      - name: Resolve version, PHP base and image
         id: vars
         run: |
           VERSION="${{ inputs.version }}"
@@ -75,65 +88,54 @@ jobs:
           if [ -z "$PHP_VERSION" ]; then
             PHP_VERSION=$(python3 -c "import json; print(json.load(open('.github/tracked-versions.json'))['base']['php'])")
           fi
+          VERSION_CLEAN="${VERSION#v}"
+          # ghcr requires a lowercase path; github.repository has mixed case.
+          IMAGE="${REGISTRY}/${GITHUB_REPOSITORY,,}"
+          RUN_TAG="${VERSION_CLEAN}-r${GITHUB_RUN_NUMBER}"
           {
             echo "version=${VERSION}"
+            echo "version_clean=${VERSION_CLEAN}"
             echo "php_version=${PHP_VERSION}"
+            echo "image=${IMAGE}"
+            echo "run_tag=${RUN_TAG}"
+            echo "short_sha=${GITHUB_SHA::7}"
           } >> "$GITHUB_OUTPUT"
-          echo "Smoke-testing upstream ${VERSION} on PHP ${PHP_VERSION}"
+          echo "Building upstream ${VERSION} on PHP ${PHP_VERSION} -> ${IMAGE}:${RUN_TAG}"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
-      # amd64 only -- enough to boot and probe; no QEMU needed on an amd64 runner.
-      - name: Build amd64 image
+      - name: Log in to ghcr.io
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Push the immutable per-run tags only. The floating :latest / :<version>
+      # tags are applied by release.yml AFTER smoke passes, so nothing a user
+      # would `docker pull` by a stable name exists until the build is verified.
+      - name: Build and push (immutable tags)
+        id: push
         uses: docker/build-push-action@v7
         with:
           context: .
-          platforms: linux/amd64
-          load: true
-          tags: unifibrowser:smoketest
+          platforms: ${{ env.PLATFORMS }}
+          push: true
+          provenance: false
           build-args: |
             PHP_VERSION=${{ steps.vars.outputs.php_version }}
             UNIFI_BROWSER_VERSION=${{ steps.vars.outputs.version }}
+          tags: |
+            ${{ steps.vars.outputs.image }}:${{ steps.vars.outputs.run_tag }}
+            ${{ steps.vars.outputs.image }}:sha-${{ steps.vars.outputs.short_sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Smoke test the image
+      - name: Report
         run: |
-          cid=$(docker run -d -p 8000:8000 unifibrowser:smoketest)
-          trap 'docker rm -f "$cid" >/dev/null 2>&1 || true' EXIT
-
-          code=000
-          for _ in $(seq 1 20); do
-            code=$(curl -s -o /dev/null -w '%{http_code}' http://localhost:8000/UniFi-API-browser/ || true)
-            [ "$code" = "200" ] && break
-            sleep 1
-          done
-          echo "HTTP status: ${code}"
-          if [ "$code" != "200" ]; then
-            echo "::error title=smoke-test::app did not return HTTP 200"
-            docker logs "$cid" || true
-            exit 1
-          fi
-
-          # Catches a fatal PHP/Twig error that still returns 200 with an error body.
-          if ! curl -s http://localhost:8000/UniFi-API-browser/ | grep -qi 'UniFi API Browser'; then
-            echo "::error title=smoke-test::login page title missing -- likely a PHP/Twig fatal"
-            docker logs "$cid" || true
-            exit 1
-          fi
-
-          # Assert PHP satisfies upstream's AUTHORITATIVE runtime floor --
-          # vendor/composer/platform_check.php, generated from the locked deps
-          # (NOT composer.json's require.php, which lags: v3.0.0 declares >=8.1
-          # but the locked deps need >=8.2, and an 8.1 image 500s on every
-          # request). Fails loudly with the exact version needed.
-          FLOOR=$(curl -fsSL "https://raw.githubusercontent.com/Art-of-WiFi/UniFi-API-browser/${{ steps.vars.outputs.version }}/vendor/composer/platform_check.php" | python3 .github/scripts/php-floor.py)
-          FLOOR_ID=$(awk -F. '{ printf "%d%02d00", $1, $2 }' <<<"$FLOOR")
-          echo "upstream PHP floor: ${FLOOR} (id ${FLOOR_ID})"
-          if ! docker exec -e FLOOR_ID="$FLOOR_ID" "$cid" php -r 'exit(PHP_VERSION_ID >= (int)getenv("FLOOR_ID") ? 0 : 1);'; then
-            echo "::error title=smoke-test::image PHP $(docker exec "$cid" php -r 'echo PHP_VERSION;') is below upstream's required ${FLOOR}. Bump base.php in .github/tracked-versions.json."
-            exit 1
-          fi
-
-          echo "smoke-test OK (PHP satisfies upstream floor ${FLOOR})"
+          echo "Pushed ${{ steps.vars.outputs.image }}:${{ steps.vars.outputs.run_tag }}"
+          echo "Digest: ${{ steps.push.outputs.digest }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,88 @@
+name: CI
+
+# Read-only PR gate. Builds the amd64 image locally and smoke-tests it (boots,
+# HTTP 200, PHP satisfies upstream's real floor). It NEVER pushes and declares
+# only `contents: read`, so it is safe against a PR-controlled Dockerfile.
+#
+# This is deliberately the ONE place build + smoke stay fused: a pull request
+# cannot push to ghcr (read-only token, by design), so there is no published
+# artifact for a separate smoke phase to pull -- it has to build locally and run
+# it in place. The decoupled build -> smoke -> publish phases (build.yml /
+# smoke.yml / release.yml) are the write-side release path.
+
+on:
+  pull_request:
+    paths:
+      - 'Dockerfile'
+      - 'files/**'
+      - '.github/workflows/ci.yml'
+      - '.github/tracked-versions.json'
+      - '.github/scripts/**'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Upstream UniFi-API-browser tag (blank = latest tracked)'
+        required: false
+        default: ''
+      php_version:
+        description: 'PHP major.minor (blank = tracked base.php)'
+        required: false
+        default: ''
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+defaults:
+  run:
+    shell: bash -euo pipefail {0}
+
+jobs:
+  build-and-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Resolve version and PHP base
+        id: vars
+        run: |
+          VERSION="${{ inputs.version }}"
+          if [ -z "$VERSION" ]; then
+            VERSION=$(python3 -c "import json; print(json.load(open('.github/tracked-versions.json'))['unifi_api_browser']['version'])")
+          fi
+          PHP_VERSION="${{ inputs.php_version }}"
+          if [ -z "$PHP_VERSION" ]; then
+            PHP_VERSION=$(python3 -c "import json; print(json.load(open('.github/tracked-versions.json'))['base']['php'])")
+          fi
+          {
+            echo "version=${VERSION}"
+            echo "php_version=${PHP_VERSION}"
+          } >> "$GITHUB_OUTPUT"
+          echo "CI build of upstream ${VERSION} on PHP ${PHP_VERSION}"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      # amd64 only -- enough to boot and probe; no QEMU needed on an amd64 runner.
+      - name: Build amd64 image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          platforms: linux/amd64
+          load: true
+          tags: unifibrowser:ci
+          build-args: |
+            PHP_VERSION=${{ steps.vars.outputs.php_version }}
+            UNIFI_BROWSER_VERSION=${{ steps.vars.outputs.version }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Smoke test
+        run: bash .github/scripts/smoke-test.sh unifibrowser:ci "${{ steps.vars.outputs.version }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,16 +1,18 @@
 name: Release image
 
-# Publishes the multi-arch image to ghcr.io with immutable per-run tags and cuts
-# an immutable GitHub Release recording the digest.
+# Golden-path orchestrator. Composes the discrete phases:
+#   build  (build.yml)  -> push multi-arch by immutable tag, output digest
+#   smoke  (smoke.yml)  -> pull that exact digest and verify it runs
+#   publish (job below) -> promote the TESTED digest to :latest / :<version>
+#                          (imagetools re-tag, NO rebuild) + cut the Release
 #
-# GATE: the `smoke` job calls the read-only build.yml workflow. If the image
-# fails to boot / serve / satisfy upstream's PHP floor, `publish` never runs --
-# so publishing carries write permissions but the PR-facing build does not.
-# Mirrors the sysext release.yml (smoke job + publish job).
+# So the image is built once, the identical artifact is smoke-tested, and only
+# then promoted -- no stable tag (:latest/:<version>) or Release exists until the
+# build is verified. Mirrors the sysext release pattern (build artifact -> gate
+# -> publish), adapted to a registry artifact.
 #
-# Triggered manually (workflow_dispatch) or dispatched by check-releases.yml when
-# a new upstream version / PHP floor is detected. With blank inputs the pin is
-# read from tracked-versions.json, so a dispatch needs no inputs.
+# Triggered manually or dispatched by check-releases.yml. Blank inputs => the pin
+# is read from tracked-versions.json, so a dispatch needs none.
 
 on:
   workflow_dispatch:
@@ -26,106 +28,73 @@ on:
 
 permissions:
   contents: write   # create the GitHub Release / tag
-  packages: write   # push the image to ghcr.io
+  packages: write   # push + re-tag in ghcr
 
 concurrency:
   group: release
   cancel-in-progress: false
-
-env:
-  REGISTRY: ghcr.io
-  PLATFORMS: linux/amd64,linux/arm64,linux/arm/v7
 
 defaults:
   run:
     shell: bash -euo pipefail {0}
 
 jobs:
-  # Required gate: read-only smoke build of the same pin. If it fails, publish
-  # never runs. Passing inputs through keeps the gate and the publish in lockstep
-  # on a manual override.
-  smoke:
+  build:
     uses: ./.github/workflows/build.yml
     with:
       version: ${{ inputs.version }}
       php_version: ${{ inputs.php_version }}
 
+  smoke:
+    needs: build
+    uses: ./.github/workflows/smoke.yml
+    with:
+      image: ${{ needs.build.outputs.image }}
+      digest: ${{ needs.build.outputs.digest }}
+      version: ${{ needs.build.outputs.version }}
+
   publish:
-    needs: smoke
+    needs: [build, smoke]
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 15
     steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Resolve version and image name
-        id: vars
-        run: |
-          VERSION="${{ inputs.version }}"
-          if [ -z "$VERSION" ]; then
-            VERSION=$(python3 -c "import json; print(json.load(open('.github/tracked-versions.json'))['unifi_api_browser']['version'])")
-          fi
-          PHP_VERSION="${{ inputs.php_version }}"
-          if [ -z "$PHP_VERSION" ]; then
-            PHP_VERSION=$(python3 -c "import json; print(json.load(open('.github/tracked-versions.json'))['base']['php'])")
-          fi
-          VERSION_CLEAN="${VERSION#v}"
-          # ghcr requires a lowercase path; github.repository has mixed case.
-          IMAGE="${REGISTRY}/${GITHUB_REPOSITORY,,}"
-          {
-            echo "version=${VERSION}"
-            echo "version_clean=${VERSION_CLEAN}"
-            echo "php_version=${PHP_VERSION}"
-            echo "image=${IMAGE}"
-            echo "short_sha=${GITHUB_SHA::7}"
-          } >> "$GITHUB_OUTPUT"
-          echo "Publishing upstream ${VERSION} on PHP ${PHP_VERSION} -> ${IMAGE}:${VERSION_CLEAN}-r${GITHUB_RUN_NUMBER}"
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
       - name: Log in to ghcr.io
         uses: docker/login-action@v4
         with:
-          registry: ${{ env.REGISTRY }}
+          registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push multi-arch image
-        id: push
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          platforms: ${{ env.PLATFORMS }}
-          push: true
-          # Keep the manifest list clean (no unknown/unknown provenance entries).
-          provenance: false
-          build-args: |
-            PHP_VERSION=${{ steps.vars.outputs.php_version }}
-            UNIFI_BROWSER_VERSION=${{ steps.vars.outputs.version }}
-          tags: |
-            ${{ steps.vars.outputs.image }}:${{ steps.vars.outputs.version_clean }}-r${{ github.run_number }}
-            ${{ steps.vars.outputs.image }}:${{ steps.vars.outputs.version_clean }}
-            ${{ steps.vars.outputs.image }}:latest
-            ${{ steps.vars.outputs.image }}:sha-${{ steps.vars.outputs.short_sha }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
-      - name: Render release notes
+      # Promote the tested digest by adding floating tags to it -- a registry
+      # metadata operation, no rebuild. The immutable <version>-r<run> + sha tags
+      # already point at this digest (pushed by build.yml).
+      - name: Promote tested digest to :latest and :<version>
         env:
-          IMAGE: ${{ steps.vars.outputs.image }}
-          VERSION: ${{ steps.vars.outputs.version }}
-          VERSION_CLEAN: ${{ steps.vars.outputs.version_clean }}
-          PHP_VERSION: ${{ steps.vars.outputs.php_version }}
-          RUN_NUMBER: ${{ github.run_number }}
-          DIGEST: ${{ steps.push.outputs.digest }}
+          IMAGE: ${{ needs.build.outputs.image }}
+          DIGEST: ${{ needs.build.outputs.digest }}
+          VERSION_CLEAN: ${{ needs.build.outputs.version_clean }}
+        run: |
+          docker buildx imagetools create \
+            --tag "${IMAGE}:latest" \
+            --tag "${IMAGE}:${VERSION_CLEAN}" \
+            "${IMAGE}@${DIGEST}"
+          echo "Promoted ${IMAGE}@${DIGEST} -> :latest, :${VERSION_CLEAN}"
+
+      - name: Create immutable GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          IMAGE: ${{ needs.build.outputs.image }}
+          VERSION: ${{ needs.build.outputs.version }}
+          VERSION_CLEAN: ${{ needs.build.outputs.version_clean }}
+          PHP_VERSION: ${{ needs.build.outputs.php_version }}
+          RUN_TAG: ${{ needs.build.outputs.run_tag }}
+          DIGEST: ${{ needs.build.outputs.digest }}
           BUILD_SHA: ${{ github.sha }}
           REPO: ${{ github.repository }}
         run: |
-          IMMUTABLE_TAG="${VERSION_CLEAN}-r${RUN_NUMBER}"
           cat > release-notes.md <<EOF
           ## UniFi API Browser container — upstream \`${VERSION}\`
 
@@ -133,13 +102,13 @@ jobs:
           | --- | --- |
           | Upstream | [Art-of-WiFi/UniFi-API-browser@${VERSION}](https://github.com/Art-of-WiFi/UniFi-API-browser/releases/tag/${VERSION}) |
           | PHP base | \`php:${PHP_VERSION}-cli-alpine\` |
-          | Immutable image | \`${IMAGE}:${IMMUTABLE_TAG}\` |
+          | Immutable image | \`${IMAGE}:${RUN_TAG}\` |
           | Digest | \`${DIGEST}\` |
           | Platforms | \`linux/amd64\`, \`linux/arm64\`, \`linux/arm/v7\` |
           | Source commit | [\`${BUILD_SHA}\`](https://github.com/${REPO}/commit/${BUILD_SHA}) |
 
-          Built and smoke-tested in CI (boots, serves HTTP 200, PHP satisfies the
-          locked runtime floor).
+          Built once, smoke-tested by digest, then promoted (boots, HTTP 200, PHP
+          satisfies the locked runtime floor).
 
           ### Pull (immutable, by digest)
           \`\`\`bash
@@ -148,7 +117,7 @@ jobs:
 
           ### Pull (this exact build)
           \`\`\`bash
-          docker pull ${IMAGE}:${IMMUTABLE_TAG}
+          docker pull ${IMAGE}:${RUN_TAG}
           \`\`\`
 
           The floating tags \`:latest\` and \`:${VERSION_CLEAN}\` also point at this build.
@@ -156,13 +125,13 @@ jobs:
           echo "=== release notes ==="
           cat release-notes.md
 
-      - name: Create immutable GitHub Release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          TAG="v${{ steps.vars.outputs.version_clean }}-r${{ github.run_number }}"
-          gh release create "$TAG" \
-            --title "UniFi API Browser v${{ steps.vars.outputs.version_clean }} (r${{ github.run_number }})" \
+          # Derive the run number from RUN_TAG (not github.run_number) so the tag
+          # and title always agree, independent of reusable-workflow run-number
+          # semantics. RUN_TAG is "<version_clean>-r<N>".
+          RUN_NUM="${RUN_TAG##*-r}"
+          gh release create "v${RUN_TAG}" \
+            --target "${BUILD_SHA}" \
+            --title "UniFi API Browser v${VERSION_CLEAN} (r${RUN_NUM})" \
             --notes-file release-notes.md \
             --latest
-          echo "Created release ${TAG}"
+          echo "Created release v${RUN_TAG}"

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,0 +1,63 @@
+name: Smoke test image
+
+# Phase 2 of the release path. Pulls a published image BY DIGEST and runs the
+# shared smoke test (boots, HTTP 200, PHP satisfies upstream's real floor) --
+# so it verifies exactly the artifact build.yml pushed, not a fresh rebuild.
+#
+# Run standalone (workflow_dispatch) to re-test any published image, or via
+# workflow_call from release.yml as the gate before publishing.
+
+on:
+  workflow_call:
+    inputs:
+      image:
+        type: string
+        required: true
+      digest:
+        type: string
+        required: true
+      version:
+        type: string
+        required: true
+  workflow_dispatch:
+    inputs:
+      image:
+        description: 'ghcr image path, e.g. ghcr.io/scyto/docker-unifibrowser'
+        required: true
+      digest:
+        description: 'Manifest digest to test, e.g. sha256:...'
+        required: true
+      version:
+        description: 'Upstream UniFi-API-browser tag (for the PHP floor lookup), e.g. v3.0.0'
+        required: true
+
+permissions:
+  contents: read   # checkout the smoke script
+  packages: read   # pull the image from ghcr
+
+defaults:
+  run:
+    shell: bash -euo pipefail {0}
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Log in to ghcr.io
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull image by digest
+        run: docker pull "${{ inputs.image }}@${{ inputs.digest }}"
+
+      - name: Smoke test
+        run: bash .github/scripts/smoke-test.sh "${{ inputs.image }}@${{ inputs.digest }}" "${{ inputs.version }}"


### PR DESCRIPTION
Splits the release path into discrete, individually-runnable phase workflows (your sysext model), composed into the golden path. **Build once → smoke the identical pushed digest → promote it** (no rebuild in publish).

## Phases
- **`build.yml`** — build multi-arch, push immutable `:<ver>-r<run>` + `:sha-<sha>` tags, output the **digest**. `workflow_call` + `workflow_dispatch`. `contents: read`, `packages: write`.
- **`smoke.yml`** — pull the image **by digest** and run the shared smoke test (so it tests exactly what build pushed). `workflow_call` + `workflow_dispatch`. Read-only.
- **`release.yml`** — golden-path orchestrator: `build → smoke → publish`. `publish` promotes the **tested digest** to `:latest` / `:<version>` via `imagetools` (no rebuild) and cuts the immutable Release. **Nothing stable-tagged or released until smoke passes.**
- **`check-releases.yml`** — unchanged; dispatches `release.yml`.

## Pushback I kept: the PR gate stays combined
- **`ci.yml`** — read-only PR gate, builds amd64 + smokes in one job. Deliberately *not* decomposed: a PR can't push (read-only token, by design), so there's no published artifact for a separate smoke phase, and merging it into the pushing `build.yml` would reopen the Codex `write-token-on-PR` finding.

Smoke logic is shared via **`.github/scripts/smoke-test.sh`** (boot, HTTP 200, PHP floor) — used by `ci.yml` (local image) and `smoke.yml` (pulled digest), so they never diverge. Verified locally: passes on php 8.2, fails on php 8.1.

This PR's own `ci.yml` check exercises the read-only gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)