### PR TITLE
Fix release.yml: gh release create needs --repo (no checkout in publish)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,7 +129,10 @@ jobs:
           # and title always agree, independent of reusable-workflow run-number
           # semantics. RUN_TAG is "<version_clean>-r<N>".
           RUN_NUM="${RUN_TAG##*-r}"
+          # --repo is required: this job has no checkout, so gh can't infer the
+          # repo from a git remote (it would fail with "not a git repository").
           gh release create "v${RUN_TAG}" \
+            --repo "${REPO}" \
             --target "${BUILD_SHA}" \
             --title "UniFi API Browser v${VERSION_CLEAN} (r${RUN_NUM})" \
             --notes-file release-notes.md \


### PR DESCRIPTION
The e2e run exposed this: in `release.yml` the `publish` job has no `actions/checkout` (it only re-tags the tested digest via `imagetools` and cuts a Release from inline notes). `gh release create` then failed with `fatal: not a git repository` because it tried to infer the repo from a git remote.

Fix: pass `--repo "${REPO}"` so `gh` doesn't need git context.

**What the e2e proved before this step:** `build` ✅ (multi-arch pushed by immutable tag + digest), `smoke` ✅ (pulled by digest, HTTP 200, floor 8.2), `imagetools` promote ✅ (`:latest` + `:3.0.0` now point at the tested digest). Only `gh release create` failed — this one line completes it.

Note: `ci.yml` can't validate this (it only build+smokes the image); it's confirmed by re-running `release.yml` after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)