### PR TITLE
Write-free build (OCI-archive artifact) + skopeo publish — true sysext model

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,13 +1,14 @@
 name: Build image
 
-# Phase 1 of the release path. Builds the multi-arch image and pushes it to ghcr
-# under an immutable per-run tag (<version>-r<run> + sha-<sha>) -- NOT the
-# floating :latest / :<version> tags, which release.yml applies only after the
-# smoke phase passes. Outputs the pushed digest so smoke.yml tests exactly this
-# artifact and release.yml promotes exactly this digest (no rebuild).
+# Phase 1 — write-free. Builds the multi-arch image to a local OCI-archive FILE
+# (image.oci.tar) and uploads it as a GitHub Actions artifact. It pushes NOTHING
+# and holds NO registry credentials (contents: read), so it is safe to run on a
+# PR-controlled Dockerfile and safe to reuse anywhere -- exactly like a sysext
+# build that produces a .raw file. smoke.yml tests that artifact; release.yml is
+# the only thing that ever pushes it.
 #
-# Run standalone (workflow_dispatch) to produce an image, or via workflow_call
-# from release.yml as the first phase of the golden path.
+# Reused by ci.yml (PR gate) and release.yml via workflow_call; runnable on its
+# own via workflow_dispatch.
 
 on:
   workflow_call:
@@ -21,23 +22,15 @@ on:
         required: false
         default: ''
     outputs:
-      image:
-        description: 'ghcr image path (no tag)'
-        value: ${{ jobs.build.outputs.image }}
-      digest:
-        description: 'Pushed manifest digest (sha256:...)'
-        value: ${{ jobs.build.outputs.digest }}
       version:
-        description: 'Resolved upstream version'
         value: ${{ jobs.build.outputs.version }}
       version_clean:
-        description: 'Resolved upstream version without leading v'
         value: ${{ jobs.build.outputs.version_clean }}
       php_version:
-        description: 'Resolved PHP base version'
         value: ${{ jobs.build.outputs.php_version }}
+      image:
+        value: ${{ jobs.build.outputs.image }}
       run_tag:
-        description: 'Immutable per-run tag pushed (<version>-r<run>)'
         value: ${{ jobs.build.outputs.run_tag }}
   workflow_dispatch:
     inputs:
@@ -52,7 +45,6 @@ on:
 
 permissions:
   contents: read
-  packages: write
 
 env:
   REGISTRY: ghcr.io
@@ -64,18 +56,19 @@ defaults:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 60
     outputs:
-      image: ${{ steps.vars.outputs.image }}
-      digest: ${{ steps.push.outputs.digest }}
       version: ${{ steps.vars.outputs.version }}
       version_clean: ${{ steps.vars.outputs.version_clean }}
       php_version: ${{ steps.vars.outputs.php_version }}
+      image: ${{ steps.vars.outputs.image }}
       run_tag: ${{ steps.vars.outputs.run_tag }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Resolve version, PHP base and image
         id: vars
@@ -98,9 +91,8 @@ jobs:
             echo "php_version=${PHP_VERSION}"
             echo "image=${IMAGE}"
             echo "run_tag=${RUN_TAG}"
-            echo "short_sha=${GITHUB_SHA::7}"
           } >> "$GITHUB_OUTPUT"
-          echo "Building upstream ${VERSION} on PHP ${PHP_VERSION} -> ${IMAGE}:${RUN_TAG}"
+          echo "Building upstream ${VERSION} on PHP ${PHP_VERSION} -> OCI archive tagged ${IMAGE}:${RUN_TAG}"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
@@ -108,34 +100,24 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
-      - name: Log in to ghcr.io
-        uses: docker/login-action@v4
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      # Push the immutable per-run tags only. The floating :latest / :<version>
-      # tags are applied by release.yml AFTER smoke passes, so nothing a user
-      # would `docker pull` by a stable name exists until the build is verified.
-      - name: Build and push (immutable tags)
-        id: push
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          platforms: ${{ env.PLATFORMS }}
-          push: true
-          provenance: false
-          build-args: |
-            PHP_VERSION=${{ steps.vars.outputs.php_version }}
-            UNIFI_BROWSER_VERSION=${{ steps.vars.outputs.version }}
-          tags: |
-            ${{ steps.vars.outputs.image }}:${{ steps.vars.outputs.run_tag }}
-            ${{ steps.vars.outputs.image }}:sha-${{ steps.vars.outputs.short_sha }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
-      - name: Report
+      # Multi-arch build to a portable OCI archive. No registry, no credentials.
+      # --provenance/--sbom off keeps the manifest a clean image index.
+      - name: Build multi-arch image to OCI archive
         run: |
-          echo "Pushed ${{ steps.vars.outputs.image }}:${{ steps.vars.outputs.run_tag }}"
-          echo "Digest: ${{ steps.push.outputs.digest }}"
+          docker buildx build \
+            --platform "${PLATFORMS}" \
+            --provenance=false --sbom=false \
+            --build-arg PHP_VERSION="${{ steps.vars.outputs.php_version }}" \
+            --build-arg UNIFI_BROWSER_VERSION="${{ steps.vars.outputs.version }}" \
+            --output "type=oci,dest=image.oci.tar" \
+            -t "${{ steps.vars.outputs.image }}:${{ steps.vars.outputs.run_tag }}" \
+            .
+          ls -lh image.oci.tar
+
+      - name: Upload image artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: image-oci
+          path: image.oci.tar
+          retention-days: 1
+          if-no-files-found: error

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,88 +1,39 @@
 name: CI
 
-# Read-only PR gate. Builds the amd64 image locally and smoke-tests it (boots,
-# HTTP 200, PHP satisfies upstream's real floor). It NEVER pushes and declares
-# only `contents: read`, so it is safe against a PR-controlled Dockerfile.
+# PR gate. A thin orchestrator that reuses the SAME phase workflows release.yml
+# uses -- build.yml then smoke.yml -- so a pull request builds the multi-arch
+# image (to an artifact) and smoke-tests its amd64 slice. Both phases run on
+# every PR, exercising build.yml/smoke.yml constantly (they are not orphaned),
+# with no reimplemented logic and no registry writes.
 #
-# This is deliberately the ONE place build + smoke stay fused: a pull request
-# cannot push to ghcr (read-only token, by design), so there is no published
-# artifact for a separate smoke phase to pull -- it has to build locally and run
-# it in place. The decoupled build -> smoke -> publish phases (build.yml /
-# smoke.yml / release.yml) are the write-side release path.
+# build + smoke must share one run so smoke can read build's artifact, which is
+# why this orchestrator exists rather than triggering build/smoke independently.
 
 on:
   pull_request:
     paths:
       - 'Dockerfile'
       - 'files/**'
+      - '.github/workflows/build.yml'
+      - '.github/workflows/smoke.yml'
       - '.github/workflows/ci.yml'
       - '.github/tracked-versions.json'
       - '.github/scripts/**'
-  workflow_dispatch:
-    inputs:
-      version:
-        description: 'Upstream UniFi-API-browser tag (blank = latest tracked)'
-        required: false
-        default: ''
-      php_version:
-        description: 'PHP major.minor (blank = tracked base.php)'
-        required: false
-        default: ''
 
 permissions:
   contents: read
+  actions: read
 
 concurrency:
-  group: ci-${{ github.event_name }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
-
-defaults:
-  run:
-    shell: bash -euo pipefail {0}
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  build-and-smoke:
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          persist-credentials: false
+  build:
+    uses: ./.github/workflows/build.yml
 
-      - name: Resolve version and PHP base
-        id: vars
-        run: |
-          VERSION="${{ inputs.version }}"
-          if [ -z "$VERSION" ]; then
-            VERSION=$(python3 -c "import json; print(json.load(open('.github/tracked-versions.json'))['unifi_api_browser']['version'])")
-          fi
-          PHP_VERSION="${{ inputs.php_version }}"
-          if [ -z "$PHP_VERSION" ]; then
-            PHP_VERSION=$(python3 -c "import json; print(json.load(open('.github/tracked-versions.json'))['base']['php'])")
-          fi
-          {
-            echo "version=${VERSION}"
-            echo "php_version=${PHP_VERSION}"
-          } >> "$GITHUB_OUTPUT"
-          echo "CI build of upstream ${VERSION} on PHP ${PHP_VERSION}"
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-
-      # amd64 only -- enough to boot and probe; no QEMU needed on an amd64 runner.
-      - name: Build amd64 image
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          platforms: linux/amd64
-          load: true
-          tags: unifibrowser:ci
-          build-args: |
-            PHP_VERSION=${{ steps.vars.outputs.php_version }}
-            UNIFI_BROWSER_VERSION=${{ steps.vars.outputs.version }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
-      - name: Smoke test
-        run: bash .github/scripts/smoke-test.sh unifibrowser:ci "${{ steps.vars.outputs.version }}"
+  smoke:
+    needs: build
+    uses: ./.github/workflows/smoke.yml
+    with:
+      version: ${{ needs.build.outputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,18 +1,16 @@
 name: Release image
 
-# Golden-path orchestrator. Composes the discrete phases:
-#   build  (build.yml)  -> push multi-arch by immutable tag, output digest
-#   smoke  (smoke.yml)  -> pull that exact digest and verify it runs
-#   publish (job below) -> promote the TESTED digest to :latest / :<version>
-#                          (imagetools re-tag, NO rebuild) + cut the Release
+# Golden-path orchestrator and the ONLY workflow that writes. Reuses the same
+# phases as ci.yml, then publishes:
+#   build  (build.yml)  -> multi-arch OCI archive artifact (write-free)
+#   smoke  (smoke.yml)  -> test that artifact's amd64 slice  (write-free)
+#   publish (job below) -> skopeo-push the SAME archive bytes to ghcr under all
+#                          tags + cut the immutable GitHub Release
 #
-# So the image is built once, the identical artifact is smoke-tested, and only
-# then promoted -- no stable tag (:latest/:<version>) or Release exists until the
-# build is verified. Mirrors the sysext release pattern (build artifact -> gate
-# -> publish), adapted to a registry artifact.
-#
-# Triggered manually or dispatched by check-releases.yml. Blank inputs => the pin
-# is read from tracked-versions.json, so a dispatch needs none.
+# So the image is built once (as a portable file, like a sysext .raw), the
+# identical artifact is smoke-tested, and only then pushed -- nothing reaches the
+# registry until smoke passes. Triggered manually or dispatched by
+# check-releases.yml; blank inputs read the pin from tracked-versions.json.
 
 on:
   workflow_dispatch:
@@ -28,7 +26,8 @@ on:
 
 permissions:
   contents: write   # create the GitHub Release / tag
-  packages: write   # push + re-tag in ghcr
+  packages: write   # push to ghcr
+  actions: read     # read the build artifact
 
 concurrency:
   group: release
@@ -49,39 +48,39 @@ jobs:
     needs: build
     uses: ./.github/workflows/smoke.yml
     with:
-      image: ${{ needs.build.outputs.image }}
-      digest: ${{ needs.build.outputs.digest }}
       version: ${{ needs.build.outputs.version }}
 
   publish:
     needs: [build, smoke]
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
     steps:
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+      - name: Download tested image artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: image-oci
 
       - name: Log in to ghcr.io
-        uses: docker/login-action@v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | skopeo login ghcr.io -u "${{ github.actor }}" --password-stdin
 
-      # Promote the tested digest by adding floating tags to it -- a registry
-      # metadata operation, no rebuild. The immutable <version>-r<run> + sha tags
-      # already point at this digest (pushed by build.yml).
-      - name: Promote tested digest to :latest and :<version>
+      # Push the EXACT bytes we smoke-tested. The immutable per-run tag and the
+      # floating :latest / :<version> tags all point at the same archive, so they
+      # share one digest. --all preserves the full multi-arch manifest list.
+      - name: Push tested archive to all tags
+        id: push
         env:
           IMAGE: ${{ needs.build.outputs.image }}
-          DIGEST: ${{ needs.build.outputs.digest }}
+          RUN_TAG: ${{ needs.build.outputs.run_tag }}
           VERSION_CLEAN: ${{ needs.build.outputs.version_clean }}
         run: |
-          docker buildx imagetools create \
-            --tag "${IMAGE}:latest" \
-            --tag "${IMAGE}:${VERSION_CLEAN}" \
-            "${IMAGE}@${DIGEST}"
-          echo "Promoted ${IMAGE}@${DIGEST} -> :latest, :${VERSION_CLEAN}"
+          SHORT="${GITHUB_SHA::7}"
+          for tag in "${RUN_TAG}" latest "${VERSION_CLEAN}" "sha-${SHORT}"; do
+            skopeo copy --all "oci-archive:image.oci.tar" "docker://${IMAGE}:${tag}"
+            echo "pushed ${IMAGE}:${tag}"
+          done
+          DIGEST=$(skopeo inspect --format '{{.Digest}}' "docker://${IMAGE}:${RUN_TAG}")
+          echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
+          echo "Published digest ${DIGEST}"
 
       - name: Create immutable GitHub Release
         env:
@@ -91,7 +90,7 @@ jobs:
           VERSION_CLEAN: ${{ needs.build.outputs.version_clean }}
           PHP_VERSION: ${{ needs.build.outputs.php_version }}
           RUN_TAG: ${{ needs.build.outputs.run_tag }}
-          DIGEST: ${{ needs.build.outputs.digest }}
+          DIGEST: ${{ steps.push.outputs.digest }}
           BUILD_SHA: ${{ github.sha }}
           REPO: ${{ github.repository }}
         run: |
@@ -107,8 +106,8 @@ jobs:
           | Platforms | \`linux/amd64\`, \`linux/arm64\`, \`linux/arm/v7\` |
           | Source commit | [\`${BUILD_SHA}\`](https://github.com/${REPO}/commit/${BUILD_SHA}) |
 
-          Built once, smoke-tested by digest, then promoted (boots, HTTP 200, PHP
-          satisfies the locked runtime floor).
+          Built once to a portable OCI archive, smoke-tested, then pushed (boots,
+          HTTP 200, PHP satisfies the locked runtime floor).
 
           ### Pull (immutable, by digest)
           \`\`\`bash
@@ -125,12 +124,8 @@ jobs:
           echo "=== release notes ==="
           cat release-notes.md
 
-          # Derive the run number from RUN_TAG (not github.run_number) so the tag
-          # and title always agree, independent of reusable-workflow run-number
-          # semantics. RUN_TAG is "<version_clean>-r<N>".
+          # --repo because this job has no checkout (gh can't infer the repo).
           RUN_NUM="${RUN_TAG##*-r}"
-          # --repo is required: this job has no checkout, so gh can't infer the
-          # repo from a git remote (it would fail with "not a git repository").
           gh release create "v${RUN_TAG}" \
             --repo "${REPO}" \
             --target "${BUILD_SHA}" \

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,39 +1,36 @@
 name: Smoke test image
 
-# Phase 2 of the release path. Pulls a published image BY DIGEST and runs the
-# shared smoke test (boots, HTTP 200, PHP satisfies upstream's real floor) --
-# so it verifies exactly the artifact build.yml pushed, not a fresh rebuild.
+# Phase 2 — write-free. Downloads the OCI-archive artifact produced by build.yml,
+# loads its amd64 slice into the local docker daemon, and runs the shared smoke
+# test (boots, HTTP 200, PHP satisfies upstream's real floor). No registry, no
+# credentials (contents: read) -- it tests exactly the artifact that will ship.
 #
-# Run standalone (workflow_dispatch) to re-test any published image, or via
-# workflow_call from release.yml as the gate before publishing.
+# Reused by ci.yml (PR gate) and release.yml via workflow_call (same-run
+# artifact); runnable on its own via workflow_dispatch by pointing it at the
+# build run that uploaded the artifact (run_id).
 
 on:
   workflow_call:
     inputs:
-      image:
-        type: string
-        required: true
-      digest:
-        type: string
-        required: true
       version:
         type: string
         required: true
+      run_id:
+        type: string
+        required: false
+        default: ''
   workflow_dispatch:
     inputs:
-      image:
-        description: 'ghcr image path, e.g. ghcr.io/scyto/docker-unifibrowser'
-        required: true
-      digest:
-        description: 'Manifest digest to test, e.g. sha256:...'
-        required: true
       version:
         description: 'Upstream UniFi-API-browser tag (for the PHP floor lookup), e.g. v3.0.0'
         required: true
+      run_id:
+        description: 'Build run id that uploaded the image-oci artifact'
+        required: true
 
 permissions:
-  contents: read   # checkout the smoke script
-  packages: read   # pull the image from ghcr
+  contents: read
+  actions: read   # read the image-oci artifact (cross-run, for standalone dispatch)
 
 defaults:
   run:
@@ -41,7 +38,7 @@ defaults:
 
 jobs:
   smoke:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     steps:
       - name: Checkout
@@ -49,15 +46,28 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Log in to ghcr.io
-        uses: docker/login-action@v4
+      # Same-run when called by ci.yml/release.yml (no run_id); cross-run when
+      # dispatched standalone against a prior build run.
+      - name: Download image artifact (same run)
+        if: inputs.run_id == ''
+        uses: actions/download-artifact@v4
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          name: image-oci
 
-      - name: Pull image by digest
-        run: docker pull "${{ inputs.image }}@${{ inputs.digest }}"
+      - name: Download image artifact (from build run)
+        if: inputs.run_id != ''
+        uses: actions/download-artifact@v4
+        with:
+          name: image-oci
+          run-id: ${{ inputs.run_id }}
+          github-token: ${{ github.token }}
+
+      # skopeo (preinstalled on ubuntu-24.04) extracts the amd64 manifest from
+      # the multi-arch archive into the docker daemon so we can run it.
+      - name: Load amd64 image from OCI archive
+        run: |
+          skopeo --override-os linux --override-arch amd64 \
+            copy oci-archive:image.oci.tar docker-daemon:unifibrowser:smoke
 
       - name: Smoke test
-        run: bash .github/scripts/smoke-test.sh "${{ inputs.image }}@${{ inputs.digest }}" "${{ inputs.version }}"
+        run: bash .github/scripts/smoke-test.sh unifibrowser:smoke "${{ inputs.version }}"


### PR DESCRIPTION
Makes the phases genuinely discrete by removing the thing that forced them together: **the build no longer pushes to a registry.** It produces a portable **OCI-archive file** — the Docker analog of a sysext `.raw` — so `build` and `smoke` are credential-free, PR-safe, reusable phases, and **only `release` writes.**

## Phases
- **`build.yml`** (`contents: read`) — `buildx` multi-arch → `image.oci.tar` → `upload-artifact`. No push, no creds. `workflow_call` + `workflow_dispatch`.
- **`smoke.yml`** (`contents: read`) — download artifact → `skopeo` load amd64 slice → shared `smoke-test.sh`. Tests the exact bytes that ship. `workflow_call` + `workflow_dispatch` (+ `run_id` for standalone).
- **`release.yml`** (`contents`/`packages: write` — the **only** writer) — `uses` build → `uses` smoke → `publish` job `skopeo`-pushes the **same archive** to all tags + cuts the immutable Release.
- **`check-releases.yml`** — unchanged; dispatches `release.yml`.

## On `ci.yml` (correction to the approved preview)
I said the preview would *delete* `ci.yml`. It can't be deleted cleanly: running `build` and `smoke` as *separate* `pull_request` runs means smoke can't read build's artifact without `workflow_run` plumbing (the option not chosen). So `ci.yml` **stays, but as a 2-line orchestrator** that `uses:` build then smoke — **both now run on every PR**, reusing the exact same workflows release uses, with **no reimplemented logic**. This actually serves the goal better (build+smoke are no longer orphaned).

## Identity contract
Like the sysext `.raw`: the **artifact bytes** are the identity. Smoke tests `image.oci.tar`; release pushes the same `image.oci.tar`. All tags (`-r<run>`, `latest`, `<version>`, `sha`) share one digest.

This PR's `ci.yml` exercises the new OCI-build + skopeo-load-amd64 + smoke path on the runner; the skopeo **push** only runs on a `release` dispatch (post-merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)