### PR TITLE
Support official UniFi API (API key) alongside classic auth

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,12 @@ ENV UNIFIURL="https://192.168.1.1"
 ENV PORT="443"
 ENV NOAPIBROWSERAUTH="0"
 ENV DISPLAYNAME="My Site Name"
+# Official UniFi Network Application API (API key auth). Leave APIKEY empty to use
+# the classic USER/PASSWORD controller above; set APIKEY to switch to the official
+# API. VERIFYSSL=true enforces TLS verification (default false for self-signed
+# UDM/UDMP certs).
+ENV APIKEY=""
+ENV VERIFYSSL="false"
 ENV APIBROWSERUSER="admin"
 
 # this sets password for APIBROWSERUSER to admin - please change when you do this

--- a/README.md
+++ b/README.md
@@ -6,19 +6,32 @@ Includes support for UniFiOS on UDMP - see note on ports
 
  The API Browser lets you pull raw, JSON formatted data from the API running on your controller.
 
+## Controller authentication: classic or official API
+
+This container talks to your controller in **one** of two mutually-exclusive modes:
+
+- **Classic (username / password)** — the default. Set `USER` + `PASSWORD`. Unchanged from previous versions.
+- **Official UniFi Network Application API (API key)** — set `APIKEY` to a key generated in your UniFi Network Application. When `APIKEY` is non-empty the container uses the official API and ignores `USER`/`PASSWORD`.
+
+Either way you still set `UNIFIURL`, `PORT`, and `DISPLAYNAME`. Pick one mode — don't set both `APIKEY` and `USER`/`PASSWORD` expecting them to combine.
+
 ## Required Environment Variables
  To run this container you will need to define the following variables:
 
 | Environment Variable | Default                     | Explanation                                                                                                                                    |
 |----------------------|-----------------------------|------------------------------------------------------------------------------------------------------------------------------------------------|
-| USER                 | Your unifi username         | Your username on unifi console - consider creating a restricted user                                                                           |
-| PASSWORD             | Your unifi password         | clear text unifi password                                                                                                                      |
+| USER                 | Your unifi username         | **Classic mode.** Your username on unifi console - consider creating a restricted user                                                          |
+| PASSWORD             | Your unifi password         | **Classic mode.** clear text unifi password                                                                                                    |
+| APIKEY               | _(empty)_                   | **Official API mode.** API key from the UniFi Network Application. Set this to use the official API instead of USER/PASSWORD; leave empty for classic mode |
+| VERIFYSSL            | false                       | **Official API mode.** Set to `true` to enforce TLS certificate verification; default `false` works with the self-signed certs on UDM / UDMP   |
 | UNIFIURL             | https://192.168.1.1         | URL to your controller *without* the port or trailing / on the URL                                                                                                      |
 | PORT                 | 443                        | Port if you changed the port unifi is running on - default env var setting 443 is now the default for UDM / UDMP for older UniFiOS based controllers change to 8443 controllers                                                                                               |
 | DISPLAYNAME          | My Site Name                | Arbitrary name you want to refer to this site as in API Browser                                                                                |
 | NOAPIBROWSERAUTH     | 0                           | use to disable browser auth
 | APIBROWSERUSER       | admin                       | username to secure the API Browser instance                                                                                                    |
 | APIBROWSERPASS       | see note | Note: Generate a SHA512 of the password you want and put here, you can use a tool like https://abunchofutils.com/u/computing/sha512-hash-calculator/ by default the password is 'admin' i.e. c7ad44cbad762a5da0a452f9e854fdc1e0e7a52a38015f23f3eab1d80b931dd472634dfac71cd34ebc35d16ab7fb8a90c81f975113d6c7538dc69dd8de9077ec|
+
+`APIBROWSERUSER` / `APIBROWSERPASS` / `NOAPIBROWSERAUTH` secure the API Browser tool itself and apply in both modes.
 
 ## Getting Running
 To get started this is the minimum number of options, be sure to append each envar with the required text (esp the SHA512):
@@ -45,6 +58,24 @@ services:
       DISPLAYNAME: Home
     image: ghcr.io/scyto/docker-unifibrowser
  ```   
+
+### Official API (API key) instead of username / password
+
+Set `APIKEY` (and omit `USER`/`PASSWORD`) to use the official UniFi Network Application API:
+```
+services:
+  unifiapibrowser:
+    ports:
+    - 8010:8000
+    environment:
+      APIKEY: your-unifi-network-application-api-key
+      VERIFYSSL: "false"   # set true only if your controller has a trusted cert
+      NOAPIBROWSERAUTH: 1
+      UNIFIURL: https://192.168.1.1
+      PORT: 443
+      DISPLAYNAME: Home
+    image: ghcr.io/scyto/docker-unifibrowser
+```
 
 ## Using Multiple Unifi Controllers
 

--- a/files/config.php
+++ b/files/config.php
@@ -22,20 +22,44 @@
  *
  * If a controller configuration is incomplete, an error will the thrown upon selection
  */
-$controllers = [
-    [
-        'user'     => getenv('USER'), // the user name for access to the Unifi Controller
-        'password' => getenv('PASSWORD'), // the password for access to the Unifi Controller
-        'url'      => getenv('UNIFIURL') . ":" . getenv('PORT'), // full url to the Unifi Controller, eg. 'https://22.22.11.11:8443'
-        'name'     => getenv('DISPLAYNAME') // name for this controller which will be used in the dropdown menu
-    ],
-#    [
-#        'user'     => 'demo2', // the user name for access to the UniFi Controller
-#        'password' => 'demo2', // the password for access to the UniFi Controller
-#        'url'      => 'https://demo.ui.com:443', // full url to the UniFi Controller, eg. 'https://22.22.11.11:8443'
-#        'name'     => 'demo2.ubnt.com'  // name for this controller which will be used in the dropdown menu
-#    ],
-];
+/**
+ * Controller selection (one mode at a time)
+ * =========================================
+ * This image configures ONE controller from environment variables in EITHER:
+ *   - Official UniFi Network Application API (API key auth) -- selected by
+ *     setting APIKEY to a non-empty value.
+ *   - Classic controller (username/password) -- the default, used whenever
+ *     APIKEY is unset/empty. Existing deployments are unaffected.
+ * The two modes are mutually exclusive: provide credentials for one or the other.
+ */
+if (getenv('APIKEY') !== false && getenv('APIKEY') !== '') {
+    // Official UniFi Network Application API (type 'official', API key auth)
+    $controllers = [
+        [
+            'type'       => 'official', // use the official API client
+            'api_key'    => getenv('APIKEY'), // API key generated in the UniFi Network Application
+            'url'        => getenv('UNIFIURL') . ":" . getenv('PORT'), // full url to the controller, eg. 'https://192.168.1.1:443'
+            'name'       => getenv('DISPLAYNAME'), // name for this controller which will be used in the dropdown menu
+            'verify_ssl' => filter_var(getenv('VERIFYSSL'), FILTER_VALIDATE_BOOLEAN), // VERIFYSSL=true enforces TLS verification; default false suits self-signed UDM/UDMP certs
+        ],
+    ];
+} else {
+    // Classic controller (username/password) -- default, backward compatible
+    $controllers = [
+        [
+            'user'     => getenv('USER'), // the user name for access to the Unifi Controller
+            'password' => getenv('PASSWORD'), // the password for access to the Unifi Controller
+            'url'      => getenv('UNIFIURL') . ":" . getenv('PORT'), // full url to the Unifi Controller, eg. 'https://22.22.11.11:8443'
+            'name'     => getenv('DISPLAYNAME'), // name for this controller which will be used in the dropdown menu
+        ],
+#        [
+#            'user'     => 'demo2', // add more controllers by editing this file directly
+#            'password' => 'demo2',
+#            'url'      => 'https://demo.ui.com:443',
+#            'name'     => 'demo2.ubnt.com'
+#        ],
+    ];
+}
 
 /**
  * Optionally change the default values for options below


### PR DESCRIPTION
Closes #19. v3.0.0 introduced the official UniFi Network Application API (API-key auth). This exposes it via env, **keeping classic username/password as the default** so existing deployments are unchanged.

## How it works
`config.php` auto-selects the mode from `APIKEY`:
- **`APIKEY` empty (default)** → classic `user`/`password` controller — byte-identical to before.
- **`APIKEY` set** → official controller (`type: official`, `api_key`, `verify_ssl`), ignoring `USER`/`PASSWORD`.

Modes are mutually exclusive (user picks one). `UNIFIURL`/`PORT`/`DISPLAYNAME` apply to both; `APIBROWSERUSER`/`PASS`/`NOAPIBROWSERAUTH` (which secure the tool itself) are unchanged.

## Changes
- **`files/config.php`** — branch on `APIKEY`.
- **`Dockerfile`** — `ENV APIKEY=""`, `ENV VERIFYSSL="false"` (false suits self-signed UDM/UDMP; set `true` to enforce TLS).
- **`README.md`** — documents both modes + an official-API compose example.

No Docker/vendor change — the official client (`art-of-wifi/unifi-network-application-api-client`) is already in upstream's committed `vendor/`.

## Verified locally
- Classic mode → `user/password` controller, no `type` (unchanged).
- Official mode → `type: official`, `api_key`, `verify_ssl: false`.
- `VERIFYSSL=true` → `verify_ssl: true`.
- App boots **HTTP 200** in both modes (the real API call needs a live controller + key, which CI can't exercise).

🤖 Generated with [Claude Code](https://claude.com/claude-code)