### PR TITLE
Silence harmless setup-qemu binfmt cache warning

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,6 +96,11 @@ jobs:
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
+        with:
+          # Don't cache the binfmt image: concurrent runs race on the same cache
+          # key and log a scary (harmless) "Unable to reserve cache" warning. The
+          # binfmt image is tiny, so re-pulling it each run is cheaper than the noise.
+          cache-image: false
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4


### PR DESCRIPTION
The multi-arch build occasionally logs:

> `Failed to save: Unable to reserve cache with key docker.io--tonistiigi--binfmt-latest-linux-x64, another job may be creating this cache.`

It's a **warning, not a failure** — concurrent runs (e.g. CI + release) race to save the same binfmt cache key; one wins, the other skips saving. Zero effect on the image. But it reads like an error and invites spurious issue reports.

Fix: `cache-image: false` on `docker/setup-qemu-action@v4` (in `build.yml`, the only place QEMU runs). The binfmt image is a few MB, so re-pulling it each run is cheaper than the noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)