### PR TITLE
Fix 'no data': leading blank line in config.php broke sessions (headers already sent)

### DIFF
--- a/files/config.php
+++ b/files/config.php
@@ -1,4 +1,3 @@
-
 <?php
 /**
  * Copyright (c) 2023, Art of WiFi


### PR DESCRIPTION
## Symptom
App loads, but no UniFi data; browser console shows AJAX responses polluted with:
> `Warning: session_start(): Session cannot be started after headers have already been sent in .../ajax/update_controller.php`
> `Warning: Cannot modify header information - headers already sent by (output started at /UniFi-API-browser/config/config.php:1)`

## Cause
`files/config.php` started with a **blank line before `<?php`**, so `require`-ing it emitted a newline. v3.0.0 calls `session_start()`/`header()` in `update_controller.php` and `common.php`, which then fail ("headers already sent"). The warning text got prepended to the AJAX JSON → `custom.js` couldn't parse it → the controller session didn't persist → `fetchSites` returned nothing.

This is a **pre-existing** issue (the blank line predates the API-key work); it only surfaced now because selecting a real controller is what exercises the session path.

## Fix
Remove the leading blank line so the file starts at byte 0 with `<?php`.

## Verified
- `config.php` now emits **0 bytes** of output.
- `require config.php; session_start();` → OK, `headers_sent()` false (the path that was failing now works).

After this is released, controller selection should persist and data should load. If a real-controller connection still returns nothing after this, that's a separate creds/SSL/API matter to chase next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)