### PR TITLE
release: sync README version title to the released version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,3 +133,41 @@ jobs:
             --notes-file release-notes.md \
             --latest
           echo "Created release v${RUN_TAG}"
+
+  # Keep the README's "# Unifi-API-Browser vX.Y.Z" title in sync with the
+  # released upstream version. Runs only after a successful publish and commits
+  # to the default branch only when the version actually changed (no-op on a
+  # re-release of the same version).
+  sync-readme:
+    needs: [build, publish]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Update README version if it differs
+        env:
+          VERSION: ${{ needs.build.outputs.version }}
+        run: |
+          file=README.md
+          current=$(sed -nE '1s/^#[[:space:]]*Unifi-API-Browser[[:space:]]+([^[:space:]]+).*/\1/Ip' "$file")
+          if [ -z "$current" ]; then
+            echo "::warning title=readme-version::could not find the version on README.md line 1; skipping"
+            exit 0
+          fi
+          if [ "$current" = "$VERSION" ]; then
+            echo "README already at ${VERSION}; nothing to do"
+            exit 0
+          fi
+          sed -i -E "1s|^(#[[:space:]]*Unifi-API-Browser[[:space:]]+)[^[:space:]]+|\1${VERSION}|I" "$file"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add "$file"
+          git commit -m "Update README version to ${VERSION}"
+          if ! git push; then
+            git pull --rebase --autostash
+            git push
+          fi
+          echo "README version ${current} -> ${VERSION}"


### PR DESCRIPTION
Adds a `sync-readme` job to `release.yml` that keeps the README's `# Unifi-API-Browser vX.Y.Z` title in step with what's actually published.

- **When:** after a successful `publish` (`needs: [build, publish]`), so the README never advertises a version that didn't ship.
- **What:** rewrites line 1's version token to `needs.build.outputs.version` (the released upstream tag) and commits to the default branch — **only if it differs** (no-op on a re-release of the same version).
- **Perms:** the job adds `contents: write`; the push is `github-actions[bot]` with a `pull --rebase` retry (same pattern as `check-releases`).

The title has sat at `v2.0.26` the whole time — the next release will sync it to `v3.0.0`.

Note: `ci.yml` doesn't trigger on `release.yml` changes, so this PR shows no checks; the job is exercised on the next `release` run. The sed extract/substitute was verified locally (`v2.0.26` → `v3.0.0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)