### PR TITLE
release: pin sync-readme checkout to the default branch (Codex #29 P2)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,6 +146,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          # Always update the DEFAULT branch's README, regardless of the ref this
+          # release was dispatched on. A bare checkout would follow the dispatch
+          # ref and commit to a maintenance branch (or fail on a tag's detached
+          # HEAD) after the image already published.
+          ref: ${{ github.event.repository.default_branch }}
 
       - name: Update README version if it differs
         env:


### PR DESCRIPTION
Addresses the Codex P2 on #29.

The `sync-readme` job used a bare `actions/checkout@v6`, which follows the **dispatch ref**, then did a bare `commit`/`push`. So a release dispatched from a non-default ref would:
- **branch** → rewrite *that branch's* README and push there (not the default branch), or
- **tag** → fail on a detached-HEAD push *after* the image already published.

Fix: pin the checkout (and thus the push) to the default branch:
```yaml
        with:
          ref: ${{ github.event.repository.default_branch }}
```
Now `sync-readme` always targets the default branch regardless of dispatch ref, and the tag-dispatch detached-HEAD failure goes away (we're on a real branch, so the `pull --rebase` retry works). No other job changes — only `sync-readme` commits.

In practice we only ever dispatch `release` on `master` (`check-releases` uses `--ref master`), so this is a latent footgun rather than an active bug — but cheap defensive correctness in the one job that writes back to the repo.

`ci.yml` doesn't gate `release.yml`, so no checks here; verified on the next real release run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)